### PR TITLE
Install ffmpeg package within the Firefox extended environment

### DIFF
--- a/environments.dhall
+++ b/environments.dhall
@@ -13,7 +13,7 @@
 , Feh =
     ./environments/feh.dhall sha256:2a1483ced20dff059f0e02f943b9a8988fe83a425f33b30ea9ba12b3c0284d6a
 , Firefox =
-    ./environments/firefox.dhall sha256:8c1fed0ba3fbe2d22c2e6777d536a7488a726c0f5ea6336ba4edc08a439f9427
+    ./environments/firefox.dhall sha256:f7f2b93021ebec7e12dc072357e3b96f9ff459d95f202d12db941043f93cc902
 , Gimp =
     ./environments/gimp.dhall sha256:eb267e094691eac20a0900d4d411b7a2caf1be3505e553720736066b016b0747
 , Git =

--- a/environments/firefox.dhall
+++ b/environments/firefox.dhall
@@ -19,6 +19,7 @@ let Extended =
         , "libva-intel-hybrid-driver"
         , "libcanberra-gtk3"
         , "pulseaudio-libs"
+        , "ffmpeg"
         ]
         (../functions/capMedia.dhall Minimal)
 

--- a/package.dhall
+++ b/package.dhall
@@ -7,11 +7,11 @@
    * 'Prelude' is a copy of the dhall-lang library 'Prelude'.
 -}
 { Defaults =
-      ./defaults.dhall sha256:96c5f587e5298106c5281b5e5cc84f97553abae4e101c59f522780f8c395084f
+      ./defaults.dhall sha256:e92c32ce91c3d6e1685d2b64df3f5d086f5a5ab9024cd82c88156f577dadc021
     : List
         ./types/Env sha256:15158bc7fa55c3d293875215bafb7d496e93453c1bd1cf945fe06dbb597e0876
 , Environments =
-    ./environments.dhall sha256:64ef02e084353eeecc91bcbd4f542ed9b40c970073c4c80cbf86ebd53da060eb
+    ./environments.dhall sha256:3b3e9877222be9873233a19e0c22195cfffedbc2aafc6a3a191ecf870b7d56dc
 , Functions =
     ./functions.dhall sha256:693ac71377a8c6be904a81c52c23da04faf113a6408020653db8b500866e73fa
 , Runtimes =


### PR DESCRIPTION
This enables the support of H264/AAC by default.
http://demo.nimius.net/video_test/