### PR TITLE
fedora: add the missing `:` in the image reference

### DIFF
--- a/Applications/fedora.dhall
+++ b/Applications/fedora.dhall
@@ -13,7 +13,7 @@ let mkUse =
 let default =
       \(version : Text) ->
         Podenv.Application::{
-        , runtime = Podenv.Image (fedora.image-ref version)
+        , runtime = Podenv.Image (fedora.image-ref (":" ++ version))
         , volumes = fedora.mkVolumes version
         , capabilities = Podenv.Capabilities::{
           , terminal = True


### PR DESCRIPTION
This change fix an issue introduced by #43