### PR TITLE
fedora: rename useCopr to avoid decoding error

### DIFF
--- a/Applications/fedora.dhall
+++ b/Applications/fedora.dhall
@@ -142,7 +142,7 @@ let base =
               //  { nonfree =
                       mkVariant "nonfree" (extraGraphic ++ extraGraphicCodec)
                   }
-      , addCopr =
+      , useCopr =
           \(name : Text) ->
             "RUN dnf -y install dnf-plugins-core && dnf -y copr enable ${name}"
       }

--- a/Applications/vcv.dhall
+++ b/Applications/vcv.dhall
@@ -5,7 +5,7 @@ let builder =
         Podenv.Container
           ( (./fedora.dhall).useGraphicImage
               "latest"
-              ((./fedora.dhall).addCopr "ycollet/linuxmao")
+              ((./fedora.dhall).useCopr "ycollet/linuxmao")
               packages
           )
 


### PR DESCRIPTION
The podenv config loader expect utility function to be named `use`.